### PR TITLE
Correct library name in docs: gtk2hs-buildtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for automatically inferring phonotactic grammars from a lexicon and using those grammars to generate random text, based on Hayes and Wilson's [A Maximum Entropy Model of Phonotactics and Phonotactic Learning](http://www.linguistics.ucla.edu/people/hayes/Phonotactics/Index.htm).  This package provides functionality both as a Haskell library, a command line tool (`phono-learner-hw`), and a GTK-based GUI (`phono-learner-hw-gui`). The library may be useful if you wish to use a custom set of candidate constraints beyond the generators offered by the two interfaces.
 
-To compile this package, run `stack build` in the root of this repository (for just the command line tool, run `stack build maxent-learner-hw`). Compiling the GUI requires GTK3 to be installed (on windows use `pacman` in the msys2 environment that comes with stack) and if initializing a new stack snapshot, will you will need to run `stack install ghc2hs-buildtools` before compilation of all dependencies can succeed.
+To compile this package, run `stack build` in the root of this repository (for just the command line tool, run `stack build maxent-learner-hw`). Compiling the GUI requires GTK3 to be installed (on windows use `pacman` in the msys2 environment that comes with stack) and if initializing a new stack snapshot, will you will need to run `stack install gtk2hs-buildtools` before compilation of all dependencies can succeed.
 
 Both the [main package](http://hackage.haskell.org/package/maxent-learner-hw) and [GUI package](http://hackage.haskell.org/package/maxent-learner-hw-gui) are also available on Hackage. Precompiled binaries for Windows and OSX are available on the Releases section on Github.
 


### PR DESCRIPTION
`ghc2hs-buildtools` to `gtk2hs-buildtools`.